### PR TITLE
No forced railtie connection

### DIFF
--- a/lib/cassandra_migrations.rb
+++ b/lib/cassandra_migrations.rb
@@ -4,5 +4,3 @@ require 'cassandra_migrations/errors'
 require 'cassandra_migrations/cassandra'
 require 'cassandra_migrations/migrator'
 require 'cassandra_migrations/migration'
-
-require 'cassandra_migrations/railtie' if defined?(Rails)

--- a/lib/cassandra_migrations.rb
+++ b/lib/cassandra_migrations.rb
@@ -4,3 +4,5 @@ require 'cassandra_migrations/errors'
 require 'cassandra_migrations/cassandra'
 require 'cassandra_migrations/migrator'
 require 'cassandra_migrations/migration'
+
+require 'cassandra_migrations/railtie' if defined?(Rails)

--- a/lib/cassandra_migrations/railtie/initializer.rb
+++ b/lib/cassandra_migrations/railtie/initializer.rb
@@ -11,18 +11,20 @@
 
 module CassandraMigrations
 
-  Cassandra.start!
+  unless Rails.env.test?
+    Cassandra.start!
 
-  if defined?(Spring)
-    Spring.after_fork do
-      Cassandra.restart
-    end
-  end
-
-  if defined?(PhusionPassenger)
-    PhusionPassenger.on_event(:starting_worker_process) do |forked|
-      if forked
+    if defined?(Spring)
+      Spring.after_fork do
         Cassandra.restart
+      end
+    end
+
+    if defined?(PhusionPassenger)
+      PhusionPassenger.on_event(:starting_worker_process) do |forked|
+        if forked
+          Cassandra.restart
+        end
       end
     end
   end

--- a/lib/cassandra_migrations/railtie/initializer.rb
+++ b/lib/cassandra_migrations/railtie/initializer.rb
@@ -8,21 +8,3 @@
 # (production tests have shown that the client is nil when forked)
 
 # More explanations in: http://www.modrails.com/documentation/Users%20guide%20Apache.html#spawning_methods_explained
-
-module CassandraMigrations
-  Cassandra.start!
-
-  if defined?(Spring)
-    Spring.after_fork do
-      Cassandra.restart
-    end
-  end
-
-  if defined?(PhusionPassenger)
-    PhusionPassenger.on_event(:starting_worker_process) do |forked|
-      if forked
-        Cassandra.restart
-      end
-    end
-  end
-end

--- a/lib/cassandra_migrations/railtie/initializer.rb
+++ b/lib/cassandra_migrations/railtie/initializer.rb
@@ -10,21 +10,18 @@
 # More explanations in: http://www.modrails.com/documentation/Users%20guide%20Apache.html#spawning_methods_explained
 
 module CassandraMigrations
+  Cassandra.start!
 
-  unless Rails.env.test?
-    Cassandra.start!
-
-    if defined?(Spring)
-      Spring.after_fork do
-        Cassandra.restart
-      end
+  if defined?(Spring)
+    Spring.after_fork do
+      Cassandra.restart
     end
+  end
 
-    if defined?(PhusionPassenger)
-      PhusionPassenger.on_event(:starting_worker_process) do |forked|
-        if forked
-          Cassandra.restart
-        end
+  if defined?(PhusionPassenger)
+    PhusionPassenger.on_event(:starting_worker_process) do |forked|
+      if forked
+        Cassandra.restart
       end
     end
   end


### PR DESCRIPTION
@linepogl The code in this file is being required in the root `cassandra_migrations.rb` file. The whole `railtie` folder needs to be required in order for `rake cassandra:create`. The whole thing that we need to remove is the code in this file to avoid the `Cassandra.start!` call every time we boot our rails app